### PR TITLE
Handle read_only and create_only fields in request

### DIFF
--- a/airflow_client/client/api/connection_api.py
+++ b/airflow_client/client/api/connection_api.py
@@ -515,7 +515,9 @@ class ConnectionApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'readonly': Connection.read_only_fields,
+                'create_only': Connection.create_only_fields
             },
             root_map={
                 'validations': {
@@ -644,7 +646,9 @@ class ConnectionApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': Connection.read_only_fields,
+                'create_only': Connection.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api/dag_api.py
+++ b/airflow_client/client/api/dag_api.py
@@ -893,7 +893,9 @@ class DAGApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': DAG.read_only_fields,
+                'create_only': DAG.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api/dag_run_api.py
+++ b/airflow_client/client/api/dag_run_api.py
@@ -704,7 +704,9 @@ class DAGRunApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': DAGRun.read_only_fields,
+                'create_only': DAGRun.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api/pool_api.py
+++ b/airflow_client/client/api/pool_api.py
@@ -515,7 +515,9 @@ class PoolApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': Pool.read_only_fields,
+                'create_only': Pool.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api/pool_api.py
+++ b/airflow_client/client/api/pool_api.py
@@ -646,7 +646,9 @@ class PoolApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': Pool.read_only_fields,
+                'create_only': Pool.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api/variable_api.py
+++ b/airflow_client/client/api/variable_api.py
@@ -520,7 +520,7 @@ class VariableApi(object):
                 'validation': [
                 ],
                 'read_only': Variable.read_only_fields,
-                'write_only': Variable.write_only_fields
+                'write_only': Variable.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api/variable_api.py
+++ b/airflow_client/client/api/variable_api.py
@@ -518,7 +518,9 @@ class VariableApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': Variable.read_only_fields,
+                'write_only': Variable.write_only_fields
             },
             root_map={
                 'validations': {
@@ -647,7 +649,9 @@ class VariableApi(object):
                 'enum': [
                 ],
                 'validation': [
-                ]
+                ],
+                'read_only': Variable.read_only_fields,
+                'create_only': Variable.create_only_fields
             },
             root_map={
                 'validations': {

--- a/airflow_client/client/api_client.py
+++ b/airflow_client/client/api_client.py
@@ -137,14 +137,17 @@ class ApiClient(object):
             #remove all read_only fields and create_only
             # TODO: raise error if create_only field in body and field is not required?
             to_remove = read_only+create_only
-            for key in to_remove:
-                body.pop(key, None)
+            if len(to_remove):
+                for key in to_remove:
+                    body.pop(key, None)
             return body
-        if method == 'POST':
+        else: # 'POST'
             #remove all read_only fields
-            for key in read_only:
-                body.pop(key, None)
+            if len(read_only):
+                for key in read_only:
+                    body.pop(key, None)
             return body
+
 
     def __call_api(
         self,

--- a/airflow_client/client/model/connection.py
+++ b/airflow_client/client/model/connection.py
@@ -74,6 +74,8 @@ class Connection(ModelComposed):
       additional_properties_type (tuple): A tuple of classes accepted
           as additional properties values.
     """
+    read_only_fields = []
+    create_only_fields = []
 
     allowed_values = {
     }

--- a/airflow_client/client/model/dag.py
+++ b/airflow_client/client/model/dag.py
@@ -74,6 +74,9 @@ class DAG(ModelNormal):
       additional_properties_type (tuple): A tuple of classes accepted
           as additional properties values.
     """
+    read_only_fields = ['dag_id', 'root_dag_id', 'is_subdag', 'fileloc',
+                        'file_token', 'owners', 'description', 'tags']
+    create_only_fields = []
 
     allowed_values = {
     }

--- a/airflow_client/client/model/dag_run.py
+++ b/airflow_client/client/model/dag_run.py
@@ -72,6 +72,9 @@ class DAGRun(ModelNormal):
       additional_properties_type (tuple): A tuple of classes accepted
           as additional properties values.
     """
+    read_only_fields = ['dag_id', 'start_date', 'end_date', 'state', 'external_trigger']
+    create_only_fields = ['execution_date']
+
 
     allowed_values = {
     }

--- a/airflow_client/client/model/pool.py
+++ b/airflow_client/client/model/pool.py
@@ -68,6 +68,8 @@ class Pool(ModelNormal):
       additional_properties_type (tuple): A tuple of classes accepted
           as additional properties values.
     """
+    read_only_fields = ['occupied_slots', 'used_slots','queued_slots','open_slots']
+    create_only_fields = []
 
     allowed_values = {
     }

--- a/airflow_client/client/model/variable.py
+++ b/airflow_client/client/model/variable.py
@@ -75,6 +75,8 @@ class Variable(ModelComposed):
           as additional properties values.
     """
 
+    read_only_fields = []
+    create_only_fields = []
     allowed_values = {
     }
 


### PR DESCRIPTION
Currently when a post request or patch request is made,
read_only fields and create_only fields are sent in the request and it fails with 400 BadRequest error, attr is readonly.
This change fixes it and ensures that readonly fields are not sent in a post/patch request

TODO:
 - [ ] Ensure all related endpoints are fixed
 - [ ] Add Test
 