### PR TITLE
Remove Version suffix for SVN while releasing

### DIFF
--- a/dev/README_RELEASE_CLIENT.md
+++ b/dev/README_RELEASE_CLIENT.md
@@ -32,6 +32,7 @@ of this the version in the built artifacts that will become the official Apache 
     ```shell script
     # Set Version
     export VERSION=2.0.0rc1
+    export VERSION_WITHOUT_RC=${VERSION%rc?}
 
 
     # Example after cloning
@@ -58,7 +59,7 @@ of this the version in the built artifacts that will become the official Apache 
 - Tarball the repo
 
     ```shell script
-    git archive --format=tar.gz ${VERSION} --prefix=apache-airflow-client-${VERSION}/ -o apache-airflow-client-${VERSION}-source.tar.gz
+    git archive --format=tar.gz ${VERSION} --prefix=apache-airflow-client-${VERSION_WITHOUT_RC}/ -o apache-airflow-client-${VERSION_WITHOUT_RC}-source.tar.gz
     ```
 
 - Generate sdist
@@ -73,17 +74,17 @@ of this the version in the built artifacts that will become the official Apache 
 - Rename the sdist
 
     ```shell script
-    mv dist/apache-airflow-client-${VERSION%rc?}.tar.gz apache-airflow-client-${VERSION}-bin.tar.gz
-    mv dist/apache_airflow_client-${VERSION%rc?}-py3-none-any.whl apache_airflow_client-${VERSION}-py3-none-any.whl
+    mv dist/apache-airflow-client-${VERSION_WITHOUT_RC}.tar.gz apache-airflow-client-${VERSION_WITHOUT_RC}-bin.tar.gz
+    mv dist/apache_airflow_client-${VERSION_WITHOUT_RC}-py3-none-any.whl apache_airflow_client-${VERSION_WITHOUT_RC}-py3-none-any.whl
     ```
 
 - Generate SHA512/ASC (If you have not generated a key yet, generate it by following instructions on
   http://www.apache.org/dev/openpgp.html#key-gen-generate-key)
 
     ```shell script
-    ${CLIENT_REPO_ROOT}/dev/sign.sh apache-airflow-client-${VERSION}-source.tar.gz
-    ${CLIENT_REPO_ROOT}/dev/sign.sh apache-airflow-client-${VERSION}-bin.tar.gz
-    ${CLIENT_REPO_ROOT}/dev/sign.sh apache_airflow_client-${VERSION}-py3-none-any.whl
+    ${CLIENT_REPO_ROOT}/dev/sign.sh apache-airflow-client-${VERSION_WITHOUT_RC}-source.tar.gz
+    ${CLIENT_REPO_ROOT}/dev/sign.sh apache-airflow-client-${VERSION_WITHOUT_RC}-bin.tar.gz
+    ${CLIENT_REPO_ROOT}/dev/sign.sh apache_airflow_client-${VERSION_WITHOUT_RC}-py3-none-any.whl
     ```
 
 - Push the artifacts to ASF dev dist repo
@@ -97,7 +98,7 @@ cd airflow-dev/clients/python
 svn mkdir ${VERSION}
 
 # Move the artifacts to svn folder & commit
-mv ${CLIENT_REPO_ROOT}/apache{-,_}*client-${VERSION}* ${VERSION}/
+mv ${CLIENT_REPO_ROOT}/apache{-,_}*client-${VERSION_WITHOUT_RC}* ${VERSION}/
 cd ${VERSION}
 svn add *
 svn commit -m "Add artifacts for Apache Airflow Python Client ${VERSION}"


### PR DESCRIPTION
same as https://github.com/apache/airflow/pull/15905 but for Python client

----

Reason explained in https://lists.apache.org/thread.html/rca430c836e5286b6d848831bdbc4f37fe5d6620ee9757e93b401495a%40%3Cdev.airflow.apache.org%3E

While working on the Helm Chart release, I was verifying what we were doing for "apache-airflow/python dists" over the weekend, which is "wrong".

We should be renaming the files as the SHA512 check fails on "Release" repo: https://dist.apache.org/repos/dist/release/airflow/2.0.2/

For example, check out 2.0.2 release on Airflow:

Since the SHA512 were generated with the original filename (with rc in it), it fails now in filename part:

```shell
❯ for i in *.sha512
do
    echo "Checking $i"; shasum -a 512 `basename $i .sha512 ` | diff - $i
done
Checking apache-airflow-2.0.2-bin.tar.gz.sha512
1c1
< 4281b3ff5d5b483c74970f8128d7ad8ba699081086fd098e10b12f8b52a7d0f92a205d7ea334c29e813ac06af7a26de416294fd18c3a1a949388a4824955ce2e  apache-airflow-2.0.2-bin.tar.gz
---
> 4281b3ff5d5b483c74970f8128d7ad8ba699081086fd098e10b12f8b52a7d0f92a205d7ea334c29e813ac06af7a26de416294fd18c3a1a949388a4824955ce2e  apache-airflow-2.0.2rc1-bin.tar.gz
Checking apache-airflow-2.0.2-source.tar.gz.sha512
1c1
< ca783369f9044796bc575bf18b986ac86998b007d01f8ff2a8c9635454d05f39fb09ce010d62249cf91badc83fd5b38c04f2b39e32830ccef70f601c5829dcb7  apache-airflow-2.0.2-source.tar.gz
---
> ca783369f9044796bc575bf18b986ac86998b007d01f8ff2a8c9635454d05f39fb09ce010d62249cf91badc83fd5b38c04f2b39e32830ccef70f601c5829dcb7  apache-airflow-2.0.2rc1-source.tar.gz
Checking apache_airflow-2.0.2-py3-none-any.whl.sha512
1c1
< 779563fd88256980ff8a994a9796d7fd18e579853c33d61e1603b084f4d150e83b3209bf1a9cd438c4dd08240b1ee48b139690ee208f80478b5b2465b7183e50  apache_airflow-2.0.2-py3-none-any.whl
---
> 779563fd88256980ff8a994a9796d7fd18e579853c33d61e1603b084f4d150e83b3209bf1a9cd438c4dd08240b1ee48b139690ee208f80478b5b2465b7183e50  apache_airflow-2.0.2rc1-py3-none-any.whl
```

I was also checking how other projects did it, Apache Spark for instance, they also just have the "rc" name in the directory
and that is all: https://dist.apache.org/repos/dist/dev/spark/v2.4.8-rc3-bin/ so it is easy to
"just move" from "dev" to "release" without changing anything.

For Airflow releases since we already do it in a directory that is named "VERSION-rcX" (example: `2.1.0rc1` in https://dist.apache.org/repos/dist/dev/airflow/2.1.0rc1/)
we don't need to add rcX in the filename of the artifact.

This helps us just moving files without renaming and changing filenames in SHA512 and is released exactly with what was voted on.

For Providers, looks like we were never adding suffix anyway:  example: https://dist.apache.org/repos/dist/dev/airflow/providers/
