### PR TITLE
Add NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Apache Airflow
+Copyright 2016-2021 The Apache Software Foundation
+
+This product includes software developed at The Apache Software
+Foundation (http://www.apache.org/).
+=======================================================================

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ url = https://airflow.apache.org/
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = Apache License 2.0
+license_files =
+   LICENSE
+   NOTICE
 project_urls =
     Documentation=https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html
     Bug Tracker=https://github.com/apache/airflow-client-python/issues


### PR DESCRIPTION
closes https://github.com/apache/airflow-client-python/issues/24

As mentioned in https://infra.apache.org/licensing-howto.html it is required by ASF policy