### PR TITLE
Issue #27 : Fixed dag details to accept None type for dag_run_timeout

### DIFF
--- a/airflow_client/client/model/dag_detail.py
+++ b/airflow_client/client/model/dag_detail.py
@@ -125,7 +125,7 @@ class DAGDetail(ModelComposed):
             'orientation': (str,),  # noqa: E501
             'concurrency': (float,),  # noqa: E501
             'start_date': (datetime, none_type,),  # noqa: E501
-            'dag_run_timeout': (TimeDelta,),  # noqa: E501
+            'dag_run_timeout': (TimeDelta, none_type),  # noqa: E501
             'doc_md': (str, none_type,),  # noqa: E501
             'default_view': (str,),  # noqa: E501
             'params': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
@@ -220,7 +220,7 @@ class DAGDetail(ModelComposed):
             orientation (str): [optional]  # noqa: E501
             concurrency (float): [optional]  # noqa: E501
             start_date (datetime, none_type): [optional]  # noqa: E501
-            dag_run_timeout (TimeDelta): [optional]  # noqa: E501
+            dag_run_timeout (TimeDelta, none_type): [optional]  # noqa: E501
             doc_md (str, none_type): [optional]  # noqa: E501
             default_view (str): [optional]  # noqa: E501
             params ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501

--- a/airflow_client/client/model/dag_detail_all_of.py
+++ b/airflow_client/client/model/dag_detail_all_of.py
@@ -100,7 +100,7 @@ class DAGDetailAllOf(ModelNormal):
             'orientation': (str,),  # noqa: E501
             'concurrency': (float,),  # noqa: E501
             'start_date': (datetime, none_type,),  # noqa: E501
-            'dag_run_timeout': (TimeDelta,),  # noqa: E501
+            'dag_run_timeout': (TimeDelta, none_type),  # noqa: E501
             'doc_md': (str, none_type,),  # noqa: E501
             'default_view': (str,),  # noqa: E501
             'params': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
@@ -174,7 +174,7 @@ class DAGDetailAllOf(ModelNormal):
             orientation (str): [optional]  # noqa: E501
             concurrency (float): [optional]  # noqa: E501
             start_date (datetime, none_type): [optional]  # noqa: E501
-            dag_run_timeout (TimeDelta): [optional]  # noqa: E501
+            dag_run_timeout (TimeDelta, none_type): [optional]  # noqa: E501
             doc_md (str, none_type): [optional]  # noqa: E501
             default_view (str): [optional]  # noqa: E501
             params ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501

--- a/airflow_client/docs/DAGDetail.md
+++ b/airflow_client/docs/DAGDetail.md
@@ -39,7 +39,7 @@ Name | Type | Description | Notes
 **orientation** | **str** |  | [optional] [readonly] 
 **concurrency** | **float** |  | [optional] [readonly] 
 **start_date** | **datetime, none_type** |  | [optional] [readonly] 
-**dag_run_timeout** | [**TimeDelta**](TimeDelta.md) |  | [optional] 
+**dag_run_timeout** | [**[TimeDelta], none_type**](TimeDelta.md) |  | [optional] 
 **doc_md** | **str, none_type** |  | [optional] [readonly] 
 **default_view** | **str** |  | [optional] [readonly] 
 **params** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** |  | [optional] [readonly] 

--- a/airflow_client/docs/DAGDetailAllOf.md
+++ b/airflow_client/docs/DAGDetailAllOf.md
@@ -28,7 +28,7 @@ Name | Type | Description | Notes
 **orientation** | **str** |  | [optional] [readonly] 
 **concurrency** | **float** |  | [optional] [readonly] 
 **start_date** | **datetime, none_type** |  | [optional] [readonly] 
-**dag_run_timeout** | [**TimeDelta**](TimeDelta.md) |  | [optional] 
+**dag_run_timeout** | [**[TimeDelta], none_type**](TimeDelta.md) |  | [optional] 
 **doc_md** | **str, none_type** |  | [optional] [readonly] 
 **default_view** | **str** |  | [optional] [readonly] 
 **params** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** |  | [optional] [readonly] 


### PR DESCRIPTION
Fix for [Issue 27:](https://github.com/apache/airflow-client-python/issues/27)

The `dag_run_timeout` in `dag_details` need to accept None type as its parameter type, because `dag_run_timeout` is an optional parameter on [DAG API](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dag/index.html#airflow.models.dag.DAG). So , most of the times this parameter will be None whenever no one is specifically mentioning it in their dags.


And It is also clearly mentioned in the definition [here](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dag/index.html#airflow.models.dag.DAG). Small extract..
`....max_active_runs: int = conf.getint('core', 'max_active_runs_per_dag'), 
dagrun_timeout: Optional[timedelta] = None,sla_miss_callback: Optional[Callable] = None,..`


So , we need to update this params to accept None type as well. Tested it on multiple dags after updating this and it worked fine.


