### PR TITLE
bug fix ApiValueError when calling get_variables()

### DIFF
--- a/airflow_client/client/model/variable_collection_item.py
+++ b/airflow_client/client/model/variable_collection_item.py
@@ -91,15 +91,16 @@ class VariableCollectionItem(ModelNormal):
         """
         return {
             'key': (str,),  # noqa: E501
+            'value': (str,),
         }
 
     @cached_property
     def discriminator():
         return None
 
-
     attribute_map = {
         'key': 'key',  # noqa: E501
+        'value': 'value',
     }
 
     _composed_schemas = {}
@@ -176,9 +177,9 @@ class VariableCollectionItem(ModelNormal):
 
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
-                        self._configuration is not None and \
-                        self._configuration.discard_unknown_keys and \
-                        self.additional_properties_type is None:
+                    self._configuration is not None and \
+                    self._configuration.discard_unknown_keys and \
+                    self.additional_properties_type is None:
                 # discard variable.
                 continue
             setattr(self, var_name, var_value)


### PR DESCRIPTION
When you try to get variables, you have ApiValueError. 

I propose a fix for that.

Here is the example code:
```Python 
import getpass
import json
import socket

import airflow_client.client
import etl.utils.templates.variable as variable
from airflow_client import client
from airflow_client.client.api import variable_api
from airflow_client.client.model.variable import Variable

local_user = input("Enter Local Airflow Admin username: ")
local_pass = getpass.getpass("Enter Local Airflow Admin password: ")
local_host = socket.gethostbyname(socket.gethostname())
configuration = airflow_client.client.Configuration(
            host=f"{local_host}:8080/api/v1",
            username=local_user,
            password=local_pass)


with client.ApiClient(configuration) as api_client:
    variable_key = "NewVar"
    var_api_instance = variable_api.VariableApi(api_client)
    vars = var_api_instance.get_variables() # raise ApiValueError
```