### PR TITLE
Update Python versions in Python client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8]
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@master


### PR DESCRIPTION
As Python version 3.6 is removed, we should also update Python versions used for building the Python Client in CI.