### PR TITLE
Revert "Use AIRFLOW_VERSION in subject"

### DIFF
--- a/dev/README_RELEASE_CLIENT.md
+++ b/dev/README_RELEASE_CLIENT.md
@@ -213,7 +213,7 @@ Subject:
 
 ```shell script
 cat <<EOF
-[VOTE] Release Airflow Python Client ${VERSION_WITHOUT_RC} from Airflow ${AIRFLOW_VERSION}
+[VOTE] Release Airflow Python Client ${VERSION_WITHOUT_RC} from ${VERSION}
 EOF
 ```
 


### PR DESCRIPTION
Reverts apache/airflow-client-python#62

As discussed with @ephraimbuddy, RC is more appropriate here, to maintain consistency with other release processes.