### PR TITLE
Add github release to release process

### DIFF
--- a/dev/README_RELEASE_CLIENT.md
+++ b/dev/README_RELEASE_CLIENT.md
@@ -397,6 +397,10 @@ At this point we release an official package:
     git push origin ${VERSION}
     ```
 
+## Create release on GitHub
+
+Create a new release on GitHub with the release notes and assets from the release svn.
+
 ## Notify developers of release
 
 See Airflow process documented [here](https://github.com/apache/airflow/blob/master/dev/README_RELEASE_AIRFLOW.md#notify-developers-of-release) (just replace Airflow with Airflow Client)


### PR DESCRIPTION
As suggested by @potiuk, creating an actual release on github from the tag would be great.

This change adds this step to the release process.