### PR TITLE
Update .rat-excludes

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,4 +1,6 @@
+# Note: these patterns are applied to single files or directories, not full paths
+# coverage/* will ignore any coverage dir, but airflow/www/static/coverage/* will match nothing
+
 .rat-excludes
 .gitignore
-airflow_client/.gitignore
-airflow_client/.openapi-generator-ignore
+.openapi-generator-ignore


### PR DESCRIPTION
While checking licence for `2.5.1rc1` we still have a complaint on `.openapi-generator-ignore` even after https://github.com/apache/airflow-client-python/pull/57

This also adds the same comment we have on [airflow](https://github.com/apache/airflow/blob/main/.rat-excludes) to avoid future confusion on the type of matching performed.

![image](https://user-images.githubusercontent.com/14861206/215354376-82d762b9-7cd3-4824-811e-0ee53c8c3667.png)
