### PR TITLE
Fix bug - Invalid type for variable for execution_timeout and dag_run_timeout 

### DIFF
--- a/airflow_client/client/model/dag_detail_all_of.py
+++ b/airflow_client/client/model/dag_detail_all_of.py
@@ -110,7 +110,7 @@ class DAGDetailAllOf(ModelNormal):
             'orientation': (str,),  # noqa: E501
             'concurrency': (float,),  # noqa: E501
             'start_date': (datetime, none_type,),  # noqa: E501
-            'dag_run_timeout': (TimeDelta,),  # noqa: E501
+            'dag_run_timeout': (TimeDelta, none_type,),  # noqa: E501
             'doc_md': (str, none_type,),  # noqa: E501
             'default_view': (str,),  # noqa: E501
             'params': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
@@ -200,7 +200,7 @@ class DAGDetailAllOf(ModelNormal):
             orientation (str): [optional]  # noqa: E501
             concurrency (float): [optional]  # noqa: E501
             start_date (datetime, none_type): The DAG's start date.  *Changed in version 2.0.1*&#58; Field becomes nullable. . [optional]  # noqa: E501
-            dag_run_timeout (TimeDelta): [optional]  # noqa: E501
+            dag_run_timeout (TimeDelta, none_type): [optional]  # noqa: E501
             doc_md (str, none_type): [optional]  # noqa: E501
             default_view (str): [optional]  # noqa: E501
             params ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): User-specified DAG params.  *New in version 2.0.1* . [optional]  # noqa: E501
@@ -295,7 +295,7 @@ class DAGDetailAllOf(ModelNormal):
             orientation (str): [optional]  # noqa: E501
             concurrency (float): [optional]  # noqa: E501
             start_date (datetime, none_type): The DAG's start date.  *Changed in version 2.0.1*&#58; Field becomes nullable. . [optional]  # noqa: E501
-            dag_run_timeout (TimeDelta): [optional]  # noqa: E501
+            dag_run_timeout (TimeDelta, none_type): [optional]  # noqa: E501
             doc_md (str, none_type): [optional]  # noqa: E501
             default_view (str): [optional]  # noqa: E501
             params ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): User-specified DAG params.  *New in version 2.0.1* . [optional]  # noqa: E501

--- a/airflow_client/client/model/task.py
+++ b/airflow_client/client/model/task.py
@@ -131,7 +131,7 @@ class Task(ModelNormal):
             'queue': (str, none_type,),  # noqa: E501
             'pool': (str,),  # noqa: E501
             'pool_slots': (float,),  # noqa: E501
-            'execution_timeout': (TimeDelta,),  # noqa: E501
+            'execution_timeout': (TimeDelta, none_type,),  # noqa: E501
             'retry_delay': (TimeDelta,),  # noqa: E501
             'retry_exponential_backoff': (bool,),  # noqa: E501
             'priority_weight': (float,),  # noqa: E501
@@ -246,7 +246,7 @@ class Task(ModelNormal):
             queue (str, none_type): [optional]  # noqa: E501
             pool (str): [optional]  # noqa: E501
             pool_slots (float): [optional]  # noqa: E501
-            execution_timeout (TimeDelta): [optional]  # noqa: E501
+            execution_timeout (TimeDelta, none_type): [optional]  # noqa: E501
             retry_delay (TimeDelta): [optional]  # noqa: E501
             retry_exponential_backoff (bool): [optional]  # noqa: E501
             priority_weight (float): [optional]  # noqa: E501
@@ -351,7 +351,7 @@ class Task(ModelNormal):
             queue (str, none_type): [optional]  # noqa: E501
             pool (str): [optional]  # noqa: E501
             pool_slots (float): [optional]  # noqa: E501
-            execution_timeout (TimeDelta): [optional]  # noqa: E501
+            execution_timeout (TimeDelta, none_type): [optional]  # noqa: E501
             retry_delay (TimeDelta): [optional]  # noqa: E501
             retry_exponential_backoff (bool): [optional]  # noqa: E501
             priority_weight (float): [optional]  # noqa: E501


### PR DESCRIPTION
Fix bug - Invalid type for variable for execution_timeout and dag_run_timeout (#53)

(cherry picked from commit f32517a63fd7367e300f0add7aff7ed3bfdde0d8)