### PR TITLE
Fix incorrect URL for project's Changelog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ license_files =
    NOTICE
 project_urls =
     Documentation=https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html
-    Changelog=https://github.com/apache/airflow-client-python/CHANGELOG.md
+    Changelog=https://github.com/apache/airflow-client-python/blob/main/CHANGELOG.md
     Bug Tracker=https://github.com/apache/airflow-client-python/issues
     Source Code=https://github.com/apache/airflow-client-python
 


### PR DESCRIPTION
On clicking the Changelog in the sidebar for the project's pypi 
listing on https://pypi.org/project/apache-airflow-client/ it says 
Not Found. The commit corrects this URL to point to the correct 
Changelog file in main for the repo.