### PR TITLE
The sanitize_for_serialization(cls, obj) function outputs an incorret time format

### DIFF
--- a/airflow_client/airflow_client/api_client.py
+++ b/airflow_client/airflow_client/api_client.py
@@ -296,7 +296,7 @@ class ApiClient(object):
         elif isinstance(obj, (str, int, float, none_type, bool)):
             return obj
         elif isinstance(obj, (datetime, date)):
-            return obj.isoformat()
+            return obj.strftime("%Y-%m-%dT%H:%M:%SZ")
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
         elif isinstance(obj, (list, tuple)):

--- a/airflow_client/client/api_client.py
+++ b/airflow_client/client/api_client.py
@@ -296,7 +296,7 @@ class ApiClient(object):
         elif isinstance(obj, (str, int, float, none_type, bool)):
             return obj
         elif isinstance(obj, (datetime, date)):
-            return obj.isoformat()
+            return obj.strftime("%Y-%m-%dT%H:%M:%SZ")
         elif isinstance(obj, ModelSimple):
             return cls.sanitize_for_serialization(obj.value)
         elif isinstance(obj, (list, tuple)):


### PR DESCRIPTION
Change obj.isoformat() used by the sanitize_for_serialization(cls, obj) function to process datetime type data to obj.strftime("%Y-%m-%dT%H:%M:%SZ"). In this way, the logical_date format of the body in the post request will be correct.