### PR TITLE
Add AGENTS.md with security-model link for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Apache Airflow Python Client — Agent Instructions
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository. It
+points them at the human-authored references they should
+consult before producing output.
+
+## Security Model
+
+The authoritative security reference for this client is the
+Apache Airflow Security Model:
+
+  https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html
+
+(Repo source: [`apache/airflow:airflow-core/docs/security/security_model.rst`](https://github.com/apache/airflow/blob/main/airflow-core/docs/security/security_model.rst).)
+
+This client library inherits Apache Airflow's security model.
+In particular, the *"What is NOT considered a security
+vulnerability"* section enumerates recurring non-findings —
+agents should consult it before reporting issues against the
+Airflow API surface this client wraps.
+
+Client-specific concerns (TLS configuration, token handling,
+retry/backoff behaviour, connection lifecycle) follow the
+guidance in the upstream Airflow model unless explicitly
+documented otherwise in this repository.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct,
reject, or discuss as needed.** Nothing here is a requirement;
the maintainer is the decision-maker.

This adds an `AGENTS.md` to `apache/airflow-client-python` so
an automated scan agent can mechanically discover the project's
security model via the conventional `AGENTS.md → model` chain.
The client library currently has no in-repo security-discovery
file, so an agent has no way to find the authoritative Airflow
security model without out-of-band knowledge.

Context: the ASF Security team is preparing the project for an
automated agentic security scan we're piloting. Such scans
refuse to run if the model isn't discoverable by that path
(refusing upfront beats wasting PMC reviewer cycles on a
noise-heavy run against an unknown model). Discoverability is
the one hard gate; everything else is suggestion. The Security
team has reached out separately on the PMC's private list with
the program details; this PR is the public-facing repo piece.

The pointer chains the client to the main Apache Airflow
security model (the same one apache/airflow's AGENTS.md
points at). The Security team uses
[threat-model-producer](https://gist.github.com/potiuk/da14a826283038ddfe38cc9fe6310573)
as the rubric for what a complete model looks like — but this
PR is just the *link*; nothing about the model content itself
changes.

Questions / pushback welcome. Happy to adjust the wording or
move the section if the project has a house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)